### PR TITLE
Use HTTPS API endpoints

### DIFF
--- a/lib/get.js
+++ b/lib/get.js
@@ -77,7 +77,7 @@ var _validateParams = function(params) {
  */
 var _createUrl = function(params) {
 
-  var baseUrl = 'http://www.omdbapi.com/';
+  var baseUrl = 'https://www.omdbapi.com/';
   var query = '?';
   
 

--- a/lib/search.js
+++ b/lib/search.js
@@ -58,7 +58,7 @@ var _validateParams = function(params) {
  */
 var _createUrl = function(params) {
 
-  var baseUrl = 'http://www.omdbapi.com/';
+  var baseUrl = 'https://www.omdbapi.com/';
   var query = '?';
   
   // mandatory


### PR DESCRIPTION
This change avoids "Mixed Content" issues when integrating this client in a web-app that itself runs over HTTPS.